### PR TITLE
Twelve hour standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /build
 
 # misc
+.vscode/
 .DS_Store
 .env.local
 .env.development.local

--- a/src/UpdatedDate.js
+++ b/src/UpdatedDate.js
@@ -22,7 +22,7 @@ export default function UpdatedDate(props) {
   return (
     <div>
       {" "}
-      {day} {hours}:{minutes}
+      {day} {(hours - 12) <= 0 ? `${hours}:${minutes} AM` : `${hours - 12}:${minutes} PM`}
     </div>
   );
 }

--- a/src/UpdatedDate.js
+++ b/src/UpdatedDate.js
@@ -11,19 +11,19 @@ export default function UpdatedDate(props) {
     "Saturday",
   ];
 
-  props = props.date
+  props = props.date;
 
   let correctedOffset = ((props.timeZoneOffset * 100) / 60 / 60);
-  correctedOffset = correctedOffset / 100
+  correctedOffset = correctedOffset / 100;
 
-  let currentDate = (new Date().toISOString()).replace(/\.\d*Z/, "")
-  props.utcDate = new Date(currentDate)
+  let currentDate = (new Date().toISOString()).replace(/\.\d*Z/, "");
+  props.utcDate = new Date(currentDate);
 
   let day = days[props.utcDate.getDay()];
   let hours = props.utcDate.getHours() + correctedOffset;
   let minutes = props.utcDate.getMinutes();
 
-  hours = hours < 0 ? 24 + hours : hours
+  hours = hours < 0 ? 24 + hours : hours;
 
   if (hours < 10) {
     hours = `0${hours}`;
@@ -31,10 +31,15 @@ export default function UpdatedDate(props) {
   if (minutes < 10) {
     minutes = `0${minutes}`;
   }
+
   return (
     <div>
       {" "}
-      {day} {(hours - 12) <= 0 ? `${hours}:${minutes} AM` : `${hours - 12}:${minutes} PM`}
+      {day} { (hours - 12) == 0 
+        ? `12:${minutes} AM` 
+        : (hours - 12) <= 0 
+          ? `${hours}:${minutes} AM` 
+          : `${hours - 12}:${minutes} PM`}
     </div>
   );
 }

--- a/src/UpdatedDate.js
+++ b/src/UpdatedDate.js
@@ -10,9 +10,21 @@ export default function UpdatedDate(props) {
     "Friday",
     "Saturday",
   ];
-  let day = days[props.date.getDay()];
-  let hours = props.date.getHours();
-  let minutes = props.date.getMinutes();
+
+  props = props.date
+
+  let correctedOffset = ((props.timeZoneOffset * 100) / 60 / 60);
+  correctedOffset = correctedOffset / 100
+
+  let currentDate = (new Date().toISOString()).replace(/\.\d*Z/, "")
+  props.utcDate = new Date(currentDate)
+
+  let day = days[props.utcDate.getDay()];
+  let hours = props.utcDate.getHours() + correctedOffset;
+  let minutes = props.utcDate.getMinutes();
+
+  hours = hours < 0 ? 24 + hours : hours
+
   if (hours < 10) {
     hours = `0${hours}`;
   }

--- a/src/Weather.js
+++ b/src/Weather.js
@@ -21,6 +21,7 @@ export default function Weather(props) {
       date: new Date(response.data.dt * 1000),
       low: response.data.main.temp_min,
       high: response.data.main.temp_max,
+      timeZoneOffset: response.data.timezone
     });
   }
 

--- a/src/WeatherInfo.js
+++ b/src/WeatherInfo.js
@@ -16,7 +16,7 @@ export default function WeatherInfo(props) {
         </span>
         <br />
         <p className="current-weather">
-          <UpdatedDate date={props.data.date} />
+          <UpdatedDate date={props.data} />
           <br />
           Low: {Math.round(props.data.low)}°F
           <br />

--- a/src/WeatherPreview.js
+++ b/src/WeatherPreview.js
@@ -6,7 +6,11 @@ export default function WeatherPreview(props) {
   function hours() {
     let date = new Date(props.data.dt * 1000);
     let hours = date.getHours();
-    const time = (hours - 12) <= 0 ? `${hours}:00 AM` : `${hours - 12}:00 PM`
+    const time = (hours - 12) == 0
+      ? `12:00 AM`
+      : (hours - 12) <= 0
+        ? `${hours}:00 AM`
+        : `${hours - 12}:00 PM`;
     return time;
   }
 

--- a/src/WeatherPreview.js
+++ b/src/WeatherPreview.js
@@ -6,7 +6,8 @@ export default function WeatherPreview(props) {
   function hours() {
     let date = new Date(props.data.dt * 1000);
     let hours = date.getHours();
-    return `${hours}:00`;
+    const time = (hours - 12) <= 0 ? `${hours}:00 AM` : `${hours - 12}:00 PM`
+    return time;
   }
 
   function temperature() {


### PR DESCRIPTION
## I wanted to contribute

So I did.

This pull request does the following:

1. Changes 24 hour time to 12 hour time within the application, only where time is used already.
2. Calibrates time to show 'local' time based on the selected city - not based on the observer. (So, if it is 9 PM EST, and I look at the weather for Los Angeles, the time shows 6 PM (PDT) instead.